### PR TITLE
Added FlowControl enum to step

### DIFF
--- a/src/step.hpp
+++ b/src/step.hpp
@@ -6,11 +6,16 @@
 #define STEP_H_
 
 namespace step {
+
+// Differentiate between manual or automatic tasks
+enum FlowControl { manual, automatic };
+
 // Step structure
 struct Step {
   std::string id;
   std::string description;
   std::function<void(void)> task;
+  FlowControl type;
   std::vector<std::reference_wrapper<Step>> dependencies;
 };
 

--- a/src/workflow.cpp
+++ b/src/workflow.cpp
@@ -28,7 +28,7 @@ Workflow makeWorkflow(vector<StepDescription> workflowDescription) {
         dependencies.push_back(ref(flow[dep]));
       }
     }
-    flow.insert({s.id, {s.id, s.description, s.task, dependencies}});
+    flow.insert({s.id, {s.id, s.description, s.task, s.type, dependencies}});
   }
 
   return flow;

--- a/src/workflow.hpp
+++ b/src/workflow.hpp
@@ -16,6 +16,7 @@ struct StepDescription {
   std::string id;
   std::string description;
   std::function<void(void)> task;
+  step::FlowControl type;
   std::vector<std::string> dependency_ids;
 };
 

--- a/tests/TestCursor.cpp
+++ b/tests/TestCursor.cpp
@@ -19,6 +19,7 @@ It should be able to mark a step as having failed.
 #include <vector>
 
 #include "cursor.hpp"
+#include "step.hpp"
 #include "workflow.hpp"
 
 using namespace workflow;
@@ -30,7 +31,7 @@ void h(void) {}
 
 TEST_CASE("simple cursor", "[cursor]") {
   SECTION("Simple Workflow") {
-    const Workflow w1 = makeWorkflow({{"a", "Step a", h, {}}});
+    const Workflow w1 = makeWorkflow({{"a", "Step a", h, step::automatic, {}}});
     // Create a cursor from the workflow
     Cursor c1{w1};
     // None of the steps have completed yet
@@ -44,9 +45,10 @@ TEST_CASE("simple cursor", "[cursor]") {
   }
 
   SECTION("Steps with dependencies") {
-    const Workflow w2 = makeWorkflow({{"a", "Step a", h, {}},
-                                      {"b", "Step b", h, {"a"}},
-                                      {"c", "Step c", h, {"b"}}});
+    const Workflow w2 =
+        makeWorkflow({{"a", "Step a", h, step::automatic, {}},
+                      {"b", "Step b", h, step::automatic, {"a"}},
+                      {"c", "Step c", h, step::automatic, {"b"}}});
     Cursor c2{w2};
 
     REQUIRE(c2.completedSteps().size() == 0);
@@ -66,10 +68,11 @@ TEST_CASE("simple cursor", "[cursor]") {
   }
 
   SECTION("Parallel Tasks") {
-    const Workflow w3 = makeWorkflow({{"a", "Add Reagent 2", h, {}},
-                                      {"b", "Preheat Heater", h, {"a"}},
-                                      {"c", "Mix Reagents", h, {"a"}},
-                                      {"d", "Heat Sample", h, {"b", "c"}}});
+    const Workflow w3 =
+        makeWorkflow({{"a", "Add Reagent 2", h, step::automatic, {}},
+                      {"b", "Preheat Heater", h, step::automatic, {"a"}},
+                      {"c", "Mix Reagents", h, step::automatic, {"a"}},
+                      {"d", "Heat Sample", h, step::automatic, {"b", "c"}}});
     Cursor c3{w3};
 
     REQUIRE(c3.completedSteps().size() == 0);
@@ -93,7 +96,7 @@ TEST_CASE("simple cursor", "[cursor]") {
   }
 
   SECTION("Failed steps") {
-    const Workflow w4 = makeWorkflow({{"a", "Step A", h, {}}});
+    const Workflow w4 = makeWorkflow({{"a", "Step A", h, step::automatic, {}}});
     Cursor c4{w4};
 
     c4.failed("a");
@@ -102,7 +105,8 @@ TEST_CASE("simple cursor", "[cursor]") {
 
   SECTION("Exceptions") {
     const Workflow w5 =
-        makeWorkflow({{"a", "Step A", h, {}}, {"b", "Step B", h, {"a"}}});
+        makeWorkflow({{"a", "Step A", h, step::automatic, {}},
+                      {"b", "Step B", h, step::automatic, {"a"}}});
     Cursor c5{w5};
 
     // Cannot complete a step which is not in the workflow

--- a/tests/TestStep.cpp
+++ b/tests/TestStep.cpp
@@ -15,15 +15,15 @@ void f(void) {}
 // This tests the output of the `get_nth_prime` function
 TEST_CASE("simple steps", "[step]") {
 
-  Step a{"a", "Step A", f, {}};
+  Step a{"a", "Step A", f, automatic, {}};
   REQUIRE(viewDependencies(a).size() == 0);
   // Depends on a
-  Step b{"b", "Step B", f, {ref(a)}};
+  Step b{"b", "Step B", f, automatic, {ref(a)}};
   REQUIRE(viewDependencies(b) == vector<string>{"a"});
   // Depends on a and b
-  Step c{"c", "Step c", f, {ref(a), ref(b)}};
+  Step c{"c", "Step c", f, automatic, {ref(a), ref(b)}};
   REQUIRE(viewDependencies(c) == vector<string>{"a", "b"});
   // Only tests direct dependency
-  Step d{"d", "Step d", f, {ref(c)}};
+  Step d{"d", "Step d", f, automatic, {ref(c)}};
   REQUIRE(viewDependencies(d) == vector<string>{"c"});
 }

--- a/tests/TestWorkflow.cpp
+++ b/tests/TestWorkflow.cpp
@@ -18,24 +18,24 @@ TEST_CASE("simple workflow", "[workflow]") {
 
   SECTION("Empty workflow") { REQUIRE(makeWorkflow({}).size() == 0); }
   SECTION("One step") {
-    Workflow w1 = makeWorkflow({{"a", "Step a", g, {}}});
+    Workflow w1 = makeWorkflow({{"a", "Step a", g, step::automatic, {}}});
     REQUIRE(w1.size() == 1);
     REQUIRE(w1["a"].id == "a");
   }
   SECTION("Linear steps") {
-    Workflow w2 = makeWorkflow({{"a", "Step a", g, {}},
-                                {"b", "Step b", g, {"a"}},
-                                {"c", "Step c", g, {"b"}}});
+    Workflow w2 = makeWorkflow({{"a", "Step a", g, step::automatic, {}},
+                                {"b", "Step b", g, step::automatic, {"a"}},
+                                {"c", "Step c", g, step::automatic, {"b"}}});
     REQUIRE(w2.size() == 3);
     REQUIRE(step::viewDependencies(w2["b"]) == vector<string>{"a"});
     REQUIRE(step::viewDependencies(w2["c"]) == vector<string>{"b"});
   }
   SECTION("Invalid Workflow") {
     // Steps not added in correct order
-    REQUIRE_THROWS(
-        makeWorkflow({{"a", "Step a", g, {"b"}}, {"b", "Step b", g, {}}}));
+    REQUIRE_THROWS(makeWorkflow({{"a", "Step a", g, step::automatic, {"b"}},
+                                 {"b", "Step b", g, step::automatic, {}}}));
     // Repeating ids
-    REQUIRE_THROWS(
-        makeWorkflow({{"a", "Step a", g, {}}, {"a", "Step b", g, {}}}));
+    REQUIRE_THROWS(makeWorkflow({{"a", "Step a", g, step::automatic, {}},
+                                 {"a", "Step b", g, step::automatic, {}}}));
   }
 }


### PR DESCRIPTION
This should provide the necessary differentiation between manual and automatic tasks.

I think that using an enum is preferable than `bool automatic` for instance, as it can be more easily expanded in the future, if there were tasks with different permission levels for instance which required different steps to be performed by the user.

In terms of laying out a workflow, this could be recorded in JSON or similar as a string value, and then later parsed into the correct enum value.

Addresses #3 